### PR TITLE
fix: resolve HA 2025.12+ compatibility issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         include:
           - python-version: "3.12"
+            homeassistant-version: "2025.1.4"
+          - python-version: "3.13"
             homeassistant-version: "2025.3.4"
-          - python-version: "3.12"
+          - python-version: "3.13"
             homeassistant-version: "2025.12.5"
-          - python-version: "3.12"
-            homeassistant-version: "2026.2.3"
           - python-version: "3.13"
             homeassistant-version: "2026.2.3"
     steps:
@@ -66,7 +66,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Configure Git
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+        homeassistant-version: ["2025.3", "2025.12", "2026.2"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -21,15 +25,21 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install black isort pylint mypy
+        pip install homeassistant==${{ matrix.homeassistant-version }}.* || pip install homeassistant>=${{ matrix.homeassistant-version }}
+        pip install pytest pytest-asyncio pytest-cov aiofiles aiohttp voluptuous
         pip install -e .
+
+    - name: Run tests
+      run: |
+        python -m pytest tests/ -v --tb=short
 
   release:
     needs: lint-and-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,17 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
-        homeassistant-version: ["2025.3", "2025.12", "2026.2"]
+        include:
+          - python-version: "3.12"
+            homeassistant-version: "2025.3.4"
+          - python-version: "3.12"
+            homeassistant-version: "2025.12.5"
+          - python-version: "3.12"
+            homeassistant-version: "2026.2.3"
+          - python-version: "3.13"
+            homeassistant-version: "2026.2.3"
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -32,10 +40,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black isort pylint mypy
-        pip install homeassistant==${{ matrix.homeassistant-version }}.* || pip install homeassistant>=${{ matrix.homeassistant-version }}
-        pip install pytest pytest-asyncio pytest-cov aiofiles aiohttp voluptuous
-        pip install -e .
+        pip install pytest pytest-asyncio pytest-cov
+        pip install "homeassistant==${{ matrix.homeassistant-version }}"
+        pip install aiofiles aiohttp voluptuous
 
     - name: Run tests
       run: |
@@ -57,9 +64,9 @@ jobs:
         ref: ${{ github.ref }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Configure Git
       run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,6 @@ name: "Lint"
 on:
   workflow_call:
 
-  #pull_request:
-  #  branches: ['main']
-  #  paths: ['custom_components/**']
-
 jobs:
   lint:
     name: "Ruff"
@@ -16,13 +12,12 @@ jobs:
           uses: "actions/checkout@v4"
 
         - name: "Set up Python"
-          uses: actions/setup-python@v4.7.1
+          uses: actions/setup-python@v5
           with:
-            python-version: "3.11"
-            cache: "pip"
+            python-version: "3.13"
 
         - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+          run: python3 -m pip install ruff
 
         - name: "Run"
           run: python3 -m ruff check .

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - name: HACS validation
         uses: "hacs/action@main"
         with:

--- a/custom_components/wakeword_installer/__init__.py
+++ b/custom_components/wakeword_installer/__init__.py
@@ -51,24 +51,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    # Register services
+    # Only register services once (first entry to load)
+    if not hass.services.has_service(DOMAIN, SERVICE_INSTALL_WAKEWORDS):
+        _register_services(hass)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register integration services."""
+
     async def install_wakewords_service(call: ServiceCall) -> None:
         """Handle install wakewords service call."""
         repo_manager = RepositoryManager(hass)
         try:
-            repositories = entry.data.get(CONF_REPOSITORIES, [])
-            target_repo = call.data.get("repository")
-            target_languages = call.data.get("languages")
-            
-            for repo in repositories:
-                if target_repo and repo[CONF_REPO_NAME] != target_repo:
-                    continue
-                    
-                languages = target_languages or repo.get("selected_languages", [])
-                await repo_manager.install_wakewords(repo["repo_url"], languages, repo[CONF_REPO_NAME])
-                
-        except Exception as e:
-            _LOGGER.error(f"Failed to install wakewords: {e}")
+            for entry_data in hass.data.get(DOMAIN, {}).values():
+                repositories = entry_data.get(CONF_REPOSITORIES, [])
+                target_repo = call.data.get("repository")
+                target_languages = call.data.get("languages")
+
+                for repo in repositories:
+                    if target_repo and repo[CONF_REPO_NAME] != target_repo:
+                        continue
+
+                    languages = target_languages or repo.get(
+                        "selected_languages", []
+                    )
+                    await repo_manager.install_wakewords(
+                        repo["repo_url"], languages, repo[CONF_REPO_NAME]
+                    )
+
+        except Exception as err:
+            _LOGGER.error("Failed to install wakewords: %s", err)
         finally:
             await repo_manager.close()
 
@@ -79,8 +94,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             repo_name = call.data["repository"]
             languages = call.data["languages"]
             await repo_manager.remove_wakewords(repo_name, languages)
-        except Exception as e:
-            _LOGGER.error(f"Failed to remove wakewords: {e}")
+        except Exception as err:
+            _LOGGER.error("Failed to remove wakewords: %s", err)
         finally:
             await repo_manager.close()
 
@@ -90,8 +105,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             repo_name = call.data["repository"]
             await repo_manager.remove_repository_wakewords(repo_name)
-        except Exception as e:
-            _LOGGER.error(f"Failed to remove repository wakewords: {e}")
+        except Exception as err:
+            _LOGGER.error("Failed to remove repository wakewords: %s", err)
         finally:
             await repo_manager.close()
 
@@ -100,9 +115,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         repo_manager = RepositoryManager(hass)
         try:
             installed = await repo_manager.get_installed_wakewords()
-            _LOGGER.info(f"Installed wakewords: {installed}")
-        except Exception as e:
-            _LOGGER.error(f"Failed to list installed wakewords: {e}")
+            _LOGGER.info("Installed wakewords: %s", installed)
+        except Exception as err:
+            _LOGGER.error("Failed to list installed wakewords: %s", err)
         finally:
             await repo_manager.close()
 
@@ -110,30 +125,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle refresh repositories service call."""
         repo_manager = RepositoryManager(hass)
         try:
-            repositories = entry.data.get(CONF_REPOSITORIES, [])
-            for repo in repositories:
-                languages = await repo_manager.get_available_languages(repo["repo_url"])
-                _LOGGER.info(f"Available languages for {repo[CONF_REPO_NAME]}: {languages}")
-        except Exception as e:
-            _LOGGER.error(f"Failed to refresh repositories: {e}")
+            for entry_data in hass.data.get(DOMAIN, {}).values():
+                repositories = entry_data.get(CONF_REPOSITORIES, [])
+                for repo in repositories:
+                    languages = await repo_manager.get_available_languages(
+                        repo["repo_url"]
+                    )
+                    _LOGGER.info(
+                        "Available languages for %s: %s",
+                        repo[CONF_REPO_NAME],
+                        languages,
+                    )
+        except Exception as err:
+            _LOGGER.error("Failed to refresh repositories: %s", err)
         finally:
             await repo_manager.close()
 
-    # Register all services
     hass.services.async_register(
-        DOMAIN, SERVICE_INSTALL_WAKEWORDS, install_wakewords_service, schema=SERVICE_INSTALL_SCHEMA
+        DOMAIN,
+        SERVICE_INSTALL_WAKEWORDS,
+        install_wakewords_service,
+        schema=SERVICE_INSTALL_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_REMOVE_WAKEWORDS, remove_wakewords_service, schema=SERVICE_REMOVE_SCHEMA
+        DOMAIN,
+        SERVICE_REMOVE_WAKEWORDS,
+        remove_wakewords_service,
+        schema=SERVICE_REMOVE_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_REMOVE_REPOSITORY_WAKEWORDS, remove_repository_wakewords_service, schema=SERVICE_REMOVE_REPOSITORY_SCHEMA
+        DOMAIN,
+        SERVICE_REMOVE_REPOSITORY_WAKEWORDS,
+        remove_repository_wakewords_service,
+        schema=SERVICE_REMOVE_REPOSITORY_SCHEMA,
     )
-    hass.services.async_register(DOMAIN, SERVICE_LIST_INSTALLED, list_installed_service)
-    hass.services.async_register(DOMAIN, SERVICE_REFRESH_REPOSITORIES, refresh_repositories_service)
-
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    return True
+    hass.services.async_register(
+        DOMAIN, SERVICE_LIST_INSTALLED, list_installed_service
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_REFRESH_REPOSITORIES, refresh_repositories_service
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -141,12 +172,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
-        
-        # Remove services
-        hass.services.async_remove(DOMAIN, SERVICE_INSTALL_WAKEWORDS)
-        hass.services.async_remove(DOMAIN, SERVICE_REMOVE_WAKEWORDS)
-        hass.services.async_remove(DOMAIN, SERVICE_REMOVE_REPOSITORY_WAKEWORDS)
-        hass.services.async_remove(DOMAIN, SERVICE_LIST_INSTALLED)
-        hass.services.async_remove(DOMAIN, SERVICE_REFRESH_REPOSITORIES)
+
+        # Only remove services when the last entry is unloaded
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_INSTALL_WAKEWORDS)
+            hass.services.async_remove(DOMAIN, SERVICE_REMOVE_WAKEWORDS)
+            hass.services.async_remove(DOMAIN, SERVICE_REMOVE_REPOSITORY_WAKEWORDS)
+            hass.services.async_remove(DOMAIN, SERVICE_LIST_INSTALLED)
+            hass.services.async_remove(DOMAIN, SERVICE_REFRESH_REPOSITORIES)
 
     return unload_ok

--- a/custom_components/wakeword_installer/config_flow.py
+++ b/custom_components/wakeword_installer/config_flow.py
@@ -51,11 +51,10 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
+        repo_manager = RepositoryManager(self.hass)
         try:
-            # Validate repository URL and fetch available languages
-            repo_manager = RepositoryManager(self.hass)
             languages = await repo_manager.get_available_languages(user_input[CONF_REPO_URL])
-            
+
             if not languages:
                 errors["base"] = "no_languages_found"
             else:
@@ -66,13 +65,13 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.available_languages = languages
                 return await self.async_step_select_languages()
 
-        except CannotConnect:
+        except HomeAssistantError:
             errors["base"] = "cannot_connect"
-        except InvalidRepo:
-            errors["base"] = "invalid_repo"
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
+        finally:
+            await repo_manager.close()
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -84,11 +83,11 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle language selection step."""
         if user_input is None:
             language_schema = vol.Schema({
-                vol.Required(CONF_SELECTED_LANGUAGES, default=self.available_languages): 
+                vol.Required(CONF_SELECTED_LANGUAGES, default=self.available_languages):
                 cv.multi_select(self.available_languages)
             })
             return self.async_show_form(
-                step_id="select_languages", 
+                step_id="select_languages",
                 data_schema=language_schema,
                 description_placeholders={
                     "repo_name": self.current_repo[CONF_REPO_NAME],
@@ -96,7 +95,6 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             )
 
-        # Add the repository with selected languages
         repo_config = {
             **self.current_repo,
             CONF_SELECTED_LANGUAGES: user_input[CONF_SELECTED_LANGUAGES]
@@ -116,14 +114,19 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required("add_another", default=False): bool
                 }),
                 description_placeholders={
-                    "current_repos": "\n".join([f"• {repo[CONF_REPO_NAME]}" for repo in self.repositories])
+                    "current_repos": "\n".join([
+                        "- %s" % repo[CONF_REPO_NAME] for repo in self.repositories
+                    ])
                 }
             )
 
         if user_input["add_another"]:
             return await self.async_step_user()
 
-        # Create the config entry
+        # Set unique ID to prevent duplicate instances
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
         return self.async_create_entry(
             title="Wakeword Installer",
             data={CONF_REPOSITORIES: self.repositories}
@@ -155,8 +158,11 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage repositories."""
         if user_input is None:
-            repo_list = [f"{repo[CONF_REPO_NAME]} ({repo[CONF_REPO_URL]})" for repo in self.repositories]
-            
+            repo_list = [
+                "%s (%s)" % (repo[CONF_REPO_NAME], repo[CONF_REPO_URL])
+                for repo in self.repositories
+            ]
+
             if not repo_list:
                 repo_list = ["No repositories configured"]
 
@@ -167,12 +173,12 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional("repo_to_remove"): vol.In(repo_list) if len(self.repositories) > 0 else str,
                 }),
                 description_placeholders={
-                    "repo_list": "\n".join([f"• {repo}" for repo in repo_list])
+                    "repo_list": "\n".join(["- %s" % repo for repo in repo_list])
                 }
             )
 
         action = user_input.get("action")
-        
+
         if action == "add":
             return await self.async_step_add_repo()
         elif action == "remove":
@@ -193,19 +199,18 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
             )
 
         errors = {}
+        repo_manager = RepositoryManager(self.hass)
         try:
-            repo_manager = RepositoryManager(self.hass)
             languages = await repo_manager.get_available_languages(user_input[CONF_REPO_URL])
-            
+
             if languages:
                 new_repo = {
                     CONF_REPO_NAME: user_input[CONF_REPO_NAME],
                     CONF_REPO_URL: user_input[CONF_REPO_URL],
-                    CONF_SELECTED_LANGUAGES: languages  # Select all by default
+                    CONF_SELECTED_LANGUAGES: languages
                 }
                 self.repositories.append(new_repo)
-                
-                # Update config entry
+
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
                     data={CONF_REPOSITORIES: self.repositories}
@@ -215,6 +220,8 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
 
         except Exception:
             errors["base"] = "unknown"
+        finally:
+            await repo_manager.close()
 
         if errors:
             return self.async_show_form(
@@ -231,22 +238,24 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
         """Remove a repository."""
         repo_to_remove = user_input.get("repo_to_remove")
         if repo_to_remove and repo_to_remove != "No repositories configured":
-            # Extract repo name from the display string
             repo_name = repo_to_remove.split(" (")[0]
-            
-            # Remove all wakeword files associated with this repository
+
+            repo_manager = RepositoryManager(self.hass)
             try:
-                repo_manager = RepositoryManager(self.hass)
                 await repo_manager.remove_repository_wakewords(repo_name)
+                _LOGGER.info("Removed all wakeword files for repository: %s", repo_name)
+            except Exception as err:
+                _LOGGER.error(
+                    "Failed to remove wakeword files for %s: %s", repo_name, err
+                )
+            finally:
                 await repo_manager.close()
-                _LOGGER.info(f"Removed all wakeword files for repository: {repo_name}")
-            except Exception as e:
-                _LOGGER.error(f"Failed to remove wakeword files for {repo_name}: {e}")
-            
-            # Remove repository from configuration
-            self.repositories = [repo for repo in self.repositories if repo[CONF_REPO_NAME] != repo_name]
-            
-            # Update config entry
+
+            self.repositories = [
+                repo for repo in self.repositories
+                if repo[CONF_REPO_NAME] != repo_name
+            ]
+
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data={CONF_REPOSITORIES: self.repositories}
@@ -259,16 +268,22 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
     ) -> ConfigFlowResult:
         """Install wakewords from repositories."""
         repo_manager = RepositoryManager(self.hass)
-        
-        for repo in self.repositories:
-            try:
-                await repo_manager.install_wakewords(
-                    repo[CONF_REPO_URL],
-                    repo[CONF_SELECTED_LANGUAGES],
-                    repo[CONF_REPO_NAME]
-                )
-            except Exception as e:
-                _LOGGER.error(f"Failed to install wakewords from {repo[CONF_REPO_NAME]}: {e}")
+        try:
+            for repo in self.repositories:
+                try:
+                    await repo_manager.install_wakewords(
+                        repo[CONF_REPO_URL],
+                        repo[CONF_SELECTED_LANGUAGES],
+                        repo[CONF_REPO_NAME]
+                    )
+                except Exception as err:
+                    _LOGGER.error(
+                        "Failed to install wakewords from %s: %s",
+                        repo[CONF_REPO_NAME],
+                        err,
+                    )
+        finally:
+            await repo_manager.close()
 
         return self.async_show_form(
             step_id="install_complete",
@@ -277,11 +292,3 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
                 "message": "Wakewords have been installed successfully!"
             }
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidRepo(HomeAssistantError):
-    """Error to indicate there is invalid repository."""

--- a/custom_components/wakeword_installer/config_flow.py
+++ b/custom_components/wakeword_installer/config_flow.py
@@ -7,8 +7,8 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
@@ -38,7 +38,7 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(
@@ -76,7 +76,7 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_select_languages(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle language selection step."""
         if user_input is None:
             language_schema = vol.Schema({
@@ -103,7 +103,7 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_add_more(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Ask if user wants to add more repositories."""
         if user_input is None:
             return self.async_show_form(
@@ -131,26 +131,24 @@ class WakewordInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> WakewordInstallerOptionsFlow:
         """Get the options flow for this handler."""
-        return WakewordInstallerOptionsFlow(config_entry)
+        return WakewordInstallerOptionsFlow()
 
 
 class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for Wakeword Installer."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-        self.repositories = config_entry.data.get(CONF_REPOSITORIES, [])
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage the options."""
+        self.repositories = list(
+            self.config_entry.data.get(CONF_REPOSITORIES, [])
+        )
         return await self.async_step_manage_repos()
 
     async def async_step_manage_repos(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage repositories."""
         if user_input is None:
             repo_list = [f"{repo[CONF_REPO_NAME]} ({repo[CONF_REPO_URL]})" for repo in self.repositories]
@@ -182,7 +180,7 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_add_repo(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Add a new repository."""
         if user_input is None:
             return self.async_show_form(
@@ -225,7 +223,7 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_remove_repo(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Remove a repository."""
         repo_to_remove = user_input.get("repo_to_remove")
         if repo_to_remove and repo_to_remove != "No repositories configured":
@@ -254,7 +252,7 @@ class WakewordInstallerOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_install_wakewords(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Install wakewords from repositories."""
         repo_manager = RepositoryManager(self.hass)
         

--- a/custom_components/wakeword_installer/config_flow.py
+++ b/custom_components/wakeword_installer/config_flow.py
@@ -7,7 +7,11 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+
+try:
+    from homeassistant.config_entries import ConfigFlowResult
+except ImportError:
+    from homeassistant.data_entry_flow import FlowResult as ConfigFlowResult
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv

--- a/custom_components/wakeword_installer/manifest.json
+++ b/custom_components/wakeword_installer/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/fwartner/home-assistant-wakeword-installer/issues",
     "requirements": ["aiohttp", "aiofiles"],
-    "version": "1.0.0"
+    "version": "1.1.0"
 }

--- a/custom_components/wakeword_installer/manifest.json
+++ b/custom_components/wakeword_installer/manifest.json
@@ -6,8 +6,8 @@
     "dependencies": [],
     "documentation": "https://github.com/fwartner/home-assistant-wakeword-installer",
     "integration_type": "service",
-    "iot_class": "local_polling",
+    "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/fwartner/home-assistant-wakeword-installer/issues",
-    "requirements": ["aiohttp", "aiofiles"],
+    "requirements": [],
     "version": "1.1.0"
 }

--- a/custom_components/wakeword_installer/repository_manager.py
+++ b/custom_components/wakeword_installer/repository_manager.py
@@ -1,13 +1,12 @@
 """Repository manager for handling GitHub repositories and wakeword files."""
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any
 
 import aiofiles
 import aiohttp
@@ -19,6 +18,10 @@ from .const import WAKEWORD_INSTALL_PATH
 
 _LOGGER = logging.getLogger(__name__)
 
+# Safety limits
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=120, connect=30)
+MAX_DOWNLOAD_SIZE = 500 * 1024 * 1024  # 500 MB
+
 
 class RepositoryManager:
     """Manage GitHub repositories and wakeword installations."""
@@ -26,7 +29,7 @@ class RepositoryManager:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the repository manager."""
         self.hass = hass
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(timeout=HTTP_TIMEOUT)
 
     async def close(self) -> None:
         """Close the aiohttp session."""
@@ -36,110 +39,127 @@ class RepositoryManager:
     async def get_available_languages(self, repo_url: str) -> list[str]:
         """Get available language folders from a GitHub repository."""
         try:
-            # Convert GitHub URL to API URL
             api_url = self._convert_to_api_url(repo_url)
-            
+
             async with self.session.get(api_url) as response:
                 if response.status != 200:
-                    raise HomeAssistantError(f"Failed to fetch repository contents: {response.status}")
-                
-                contents = await response.json()
-                
-                # Filter for directories (language folders)
-                languages = []
-                for item in contents:
-                    if item["type"] == "dir":
-                        languages.append(item["name"])
-                
-                return sorted(languages)
-                
-        except aiohttp.ClientError as e:
-            _LOGGER.error(f"Network error while fetching repository: {e}")
-            raise HomeAssistantError(f"Cannot connect to repository: {e}")
-        except Exception as e:
-            _LOGGER.error(f"Error parsing repository contents: {e}")
-            raise HomeAssistantError(f"Invalid repository structure: {e}")
+                    raise HomeAssistantError(
+                        "Failed to fetch repository contents: %s" % response.status
+                    )
 
-    async def install_wakewords(self, repo_url: str, selected_languages: list[str], repo_name: str | None = None) -> None:
+                contents = await response.json()
+
+                languages = [
+                    item["name"] for item in contents if item["type"] == "dir"
+                ]
+                return sorted(languages)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Network error while fetching repository: %s", err)
+            raise HomeAssistantError("Cannot connect to repository: %s" % err)
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            _LOGGER.error("Error parsing repository contents: %s", err)
+            raise HomeAssistantError("Invalid repository structure: %s" % err)
+
+    async def install_wakewords(
+        self,
+        repo_url: str,
+        selected_languages: list[str],
+        repo_name: str | None = None,
+    ) -> None:
         """Install wakeword files from repository for selected languages."""
         try:
-            # Create installation directory if it doesn't exist
             install_path = Path(WAKEWORD_INSTALL_PATH)
-            install_path.mkdir(parents=True, exist_ok=True)
-            
-            # Extract repository name from URL if not provided
+            await self.hass.async_add_executor_job(
+                install_path.mkdir, 0o777, True, True
+            )
+
             if repo_name is None:
                 repo_name = self._extract_repo_name(repo_url)
-            
-            # Download repository as zip
+
             download_url = self._get_download_url(repo_url)
-            
+
             with tempfile.TemporaryDirectory() as temp_dir:
                 zip_path = Path(temp_dir) / "repo.zip"
-                
-                # Download the repository
+
                 await self._download_file(download_url, zip_path)
-                
-                # Extract and install files
-                await self._extract_and_install(zip_path, selected_languages, install_path, repo_name)
-                
-            _LOGGER.info(f"Successfully installed wakewords for languages: {selected_languages}")
-            
-        except Exception as e:
-            _LOGGER.error(f"Failed to install wakewords: {e}")
-            raise HomeAssistantError(f"Installation failed: {e}")
+
+                await self._extract_and_install(
+                    zip_path, selected_languages, install_path, repo_name, temp_dir
+                )
+
+            _LOGGER.info(
+                "Successfully installed wakewords for languages: %s",
+                selected_languages,
+            )
+
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            _LOGGER.error("Failed to install wakewords: %s", err)
+            raise HomeAssistantError("Installation failed: %s" % err)
 
     def _extract_repo_name(self, repo_url: str) -> str:
         """Extract repository name from URL."""
-        # Handle different GitHub URL formats
         if repo_url.startswith("https://github.com/"):
             repo_path = repo_url.replace("https://github.com/", "")
         elif repo_url.startswith("github.com/"):
             repo_path = repo_url.replace("github.com/", "")
         else:
             return "unknown-repo"
-        
-        # Remove .git suffix if present
+
         if repo_path.endswith(".git"):
             repo_path = repo_path[:-4]
-        
-        # Remove trailing slash and get just the repo name
+
         repo_path = repo_path.rstrip("/")
         return repo_path.split("/")[-1] if "/" in repo_path else repo_path
 
-    async def remove_wakewords(self, repo_name: str, languages: list[str] | None = None) -> None:
-        """Remove installed wakeword files for specific languages or all files from a repository.
-        
+    async def remove_wakewords(
+        self, repo_name: str, languages: list[str] | None = None
+    ) -> None:
+        """Remove installed wakeword files.
+
         Args:
-            repo_name: Name of the repository
-            languages: List of languages to remove. If None, removes all files from the repository.
+            repo_name: Name of the repository.
+            languages: Languages to remove. If None, removes all from this repo.
         """
-        try:
+
+        def _remove_sync() -> None:
             install_path = Path(WAKEWORD_INSTALL_PATH)
-            
+            if not install_path.exists():
+                return
+
             if languages is None:
-                # Remove all files from this repository
-                repo_files = install_path.glob(f"*{repo_name}*.tflite")
-                for file_path in repo_files:
+                # Format: {repo_name}_{language}_{original_name}.tflite
+                for file_path in install_path.glob("%s_*.tflite" % repo_name):
                     try:
                         file_path.unlink()
-                        _LOGGER.info(f"Removed wakeword file: {file_path}")
-                    except OSError as e:
-                        _LOGGER.warning(f"Failed to remove file {file_path}: {e}")
+                        _LOGGER.info("Removed wakeword file: %s", file_path.name)
+                    except OSError as err:
+                        _LOGGER.warning(
+                            "Failed to remove file %s: %s", file_path, err
+                        )
             else:
-                # Remove files for specific languages
                 for language in languages:
-                    language_files = install_path.glob(f"{language}_*{repo_name}*.tflite")
-                    for file_path in language_files:
+                    pattern = "%s_%s_*.tflite" % (repo_name, language)
+                    for file_path in install_path.glob(pattern):
                         try:
                             file_path.unlink()
-                            _LOGGER.info(f"Removed wakeword file: {file_path}")
-                        except OSError as e:
-                            _LOGGER.warning(f"Failed to remove file {file_path}: {e}")
-                        
-        except Exception as e:
-            _LOGGER.error(f"Failed to remove wakewords: {e}")
-            raise HomeAssistantError(f"Removal failed: {e}")
+                            _LOGGER.info(
+                                "Removed wakeword file: %s", file_path.name
+                            )
+                        except OSError as err:
+                            _LOGGER.warning(
+                                "Failed to remove file %s: %s", file_path, err
+                            )
+
+        try:
+            await self.hass.async_add_executor_job(_remove_sync)
+        except Exception as err:
+            _LOGGER.error("Failed to remove wakewords: %s", err)
+            raise HomeAssistantError("Removal failed: %s" % err)
 
     async def remove_repository_wakewords(self, repo_name: str) -> None:
         """Remove all wakeword files associated with a repository."""
@@ -147,22 +167,18 @@ class RepositoryManager:
 
     def _convert_to_api_url(self, repo_url: str) -> str:
         """Convert GitHub repository URL to API URL."""
-        # Handle different GitHub URL formats
         if repo_url.startswith("https://github.com/"):
             repo_path = repo_url.replace("https://github.com/", "")
         elif repo_url.startswith("github.com/"):
             repo_path = repo_url.replace("github.com/", "")
         else:
             raise HomeAssistantError("Invalid GitHub repository URL")
-        
-        # Remove .git suffix if present
+
         if repo_path.endswith(".git"):
             repo_path = repo_path[:-4]
-        
-        # Remove trailing slash
+
         repo_path = repo_path.rstrip("/")
-        
-        return f"https://api.github.com/repos/{repo_path}/contents"
+        return "https://api.github.com/repos/%s/contents" % repo_path
 
     def _get_download_url(self, repo_url: str) -> str:
         """Get the download URL for the repository zip."""
@@ -172,105 +188,133 @@ class RepositoryManager:
             repo_path = repo_url.replace("github.com/", "")
         else:
             raise HomeAssistantError("Invalid GitHub repository URL")
-        
+
         if repo_path.endswith(".git"):
             repo_path = repo_path[:-4]
-        
+
         repo_path = repo_path.rstrip("/")
-        
-        return f"https://github.com/{repo_path}/archive/refs/heads/main.zip"
+        return "https://github.com/%s/archive/refs/heads/main.zip" % repo_path
 
     async def _download_file(self, url: str, file_path: Path) -> None:
-        """Download a file from URL to local path."""
+        """Download a file from URL to local path with size limit."""
         try:
             async with self.session.get(url) as response:
                 if response.status != 200:
-                    raise HomeAssistantError(f"Failed to download file: {response.status}")
-                
-                async with aiofiles.open(file_path, 'wb') as file:
-                    async for chunk in response.content.iter_chunked(8192):
-                        await file.write(chunk)
-                        
-        except aiohttp.ClientError as e:
-            raise HomeAssistantError(f"Download failed: {e}")
+                    raise HomeAssistantError(
+                        "Failed to download file: %s" % response.status
+                    )
 
-    async def _extract_and_install(self, zip_path: Path, selected_languages: list[str], install_path: Path, repo_name: str) -> None:
+                # Check content-length if available
+                content_length = response.content_length
+                if content_length and content_length > MAX_DOWNLOAD_SIZE:
+                    raise HomeAssistantError(
+                        "Download too large: %d bytes (max %d)"
+                        % (content_length, MAX_DOWNLOAD_SIZE)
+                    )
+
+                total_size = 0
+                async with aiofiles.open(file_path, "wb") as file:
+                    async for chunk in response.content.iter_chunked(8192):
+                        total_size += len(chunk)
+                        if total_size > MAX_DOWNLOAD_SIZE:
+                            raise HomeAssistantError(
+                                "Download exceeded size limit of %d bytes"
+                                % MAX_DOWNLOAD_SIZE
+                            )
+                        await file.write(chunk)
+
+        except aiohttp.ClientError as err:
+            raise HomeAssistantError("Download failed: %s" % err)
+
+    async def _extract_and_install(
+        self,
+        zip_path: Path,
+        selected_languages: list[str],
+        install_path: Path,
+        repo_name: str,
+        temp_dir: str,
+    ) -> None:
         """Extract zip file and install tflite files for selected languages."""
-        def extract_sync():
-            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-                # Get all files in the zip
+
+        def extract_sync() -> None:
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
                 all_files = zip_ref.namelist()
-                
-                # Filter for tflite files in selected language directories
+
                 tflite_files = []
-                for file_path in all_files:
-                    if file_path.endswith('.tflite'):
-                        # Check if file is in one of the selected language directories
-                        path_parts = file_path.split('/')
+                for entry in all_files:
+                    if entry.endswith(".tflite"):
+                        path_parts = entry.split("/")
                         if len(path_parts) >= 2:
-                            # Check if any part of the path matches selected languages
                             for language in selected_languages:
                                 if language in path_parts:
-                                    tflite_files.append(file_path)
+                                    tflite_files.append(entry)
                                     break
-                
-                # Extract and install the tflite files
+
                 for tflite_file in tflite_files:
                     try:
-                        # Extract to temporary location
-                        temp_file = zip_ref.extract(tflite_file)
-                        
-                        # Generate new filename with repo name, language, and original name
+                        # Zip-slip protection: extract to temp_dir and validate
+                        member_info = zip_ref.getinfo(tflite_file)
+                        extracted = zip_ref.extract(member_info, path=temp_dir)
+                        real_extracted = os.path.realpath(extracted)
+                        real_temp = os.path.realpath(temp_dir)
+                        if not real_extracted.startswith(real_temp + os.sep):
+                            _LOGGER.warning(
+                                "Skipping suspicious zip entry: %s", tflite_file
+                            )
+                            continue
+
                         original_name = Path(tflite_file).name
-                        
-                        # Try to determine language from path
+
                         language = "unknown"
-                        path_parts = tflite_file.split('/')
+                        path_parts = tflite_file.split("/")
                         for part in path_parts:
                             if part in selected_languages:
                                 language = part
                                 break
-                        
+
                         # Format: {repo_name}_{language}_{original_name}
-                        new_name = f"{repo_name}_{language}_{original_name}"
+                        new_name = "%s_%s_%s" % (repo_name, language, original_name)
                         destination = install_path / new_name
-                        
-                        # Move file to installation directory
-                        import shutil
-                        shutil.move(temp_file, destination)
-                        
-                        _LOGGER.info(f"Installed wakeword: {new_name}")
-                        
-                    except Exception as e:
-                        _LOGGER.warning(f"Failed to install {tflite_file}: {e}")
-        
-        # Run the synchronous extraction in a thread
+
+                        shutil.move(extracted, destination)
+
+                        _LOGGER.info("Installed wakeword: %s", new_name)
+
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to install %s: %s", tflite_file, err
+                        )
+
         await self.hass.async_add_executor_job(extract_sync)
 
     async def get_installed_wakewords(self) -> dict[str, list[str]]:
         """Get list of currently installed wakeword files organized by language."""
-        try:
+
+        def _list_sync() -> dict[str, list[str]]:
             install_path = Path(WAKEWORD_INSTALL_PATH)
             if not install_path.exists():
                 return {}
-            
-            installed = {}
+
+            installed: dict[str, list[str]] = {}
             for tflite_file in install_path.glob("*.tflite"):
                 filename = tflite_file.name
-                
-                # Try to extract language from filename
-                if "_" in filename:
-                    language = filename.split("_")[0]
+
+                # Format: {repo_name}_{language}_{original_name}
+                parts = filename.split("_")
+                if len(parts) >= 3:
+                    language = parts[1]
                 else:
                     language = "unknown"
-                
+
                 if language not in installed:
                     installed[language] = []
-                
+
                 installed[language].append(filename)
-            
+
             return installed
-            
-        except Exception as e:
-            _LOGGER.error(f"Failed to get installed wakewords: {e}")
+
+        try:
+            return await self.hass.async_add_executor_job(_list_sync)
+        except Exception as err:
+            _LOGGER.error("Failed to get installed wakewords: %s", err)
             return {}

--- a/custom_components/wakeword_installer/repository_manager.py
+++ b/custom_components/wakeword_installer/repository_manager.py
@@ -245,7 +245,7 @@ class RepositoryManager:
                         _LOGGER.warning(f"Failed to install {tflite_file}: {e}")
         
         # Run the synchronous extraction in a thread
-        await asyncio.get_event_loop().run_in_executor(None, extract_sync)
+        await self.hass.async_add_executor_job(extract_sync)
 
     async def get_installed_wakewords(self) -> dict[str, list[str]]:
         """Get list of currently installed wakeword files organized by language."""

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "Wakeword Installer",
     "content_in_root": false,
-    "filename": "wakeword_installer.zip",
     "render_readme": true,
     "homeassistant": "2024.1.0",
     "zip_release": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,3 +162,8 @@ module = [
     "custom_components.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+pythonpath = ["."]

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "automerge": true,
     "automergeType": "pr",
     "baseBranches": [
-        "dev"
+        "main"
     ],
     "labels": [
         "dependencies"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,7 @@ safety>=2.3.0
 pre-commit>=3.0.0
 yamllint>=1.32.0
 codespell>=2.2.0
+pytest>=7.4.0
+pytest-asyncio>=0.23.0
+pytest-cov>=4.1.0
 homeassistant>=2024.1.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Wakeword Installer integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Shared fixtures for Wakeword Installer tests."""
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,6 +23,7 @@ def mock_hass() -> MagicMock:
     hass.services = MagicMock()
     hass.services.async_register = MagicMock()
     hass.services.async_remove = MagicMock()
+    hass.services.has_service = MagicMock(return_value=False)
     hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     return hass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+"""Shared fixtures for Wakeword Installer tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.wakeword_installer.const import DOMAIN, CONF_REPOSITORIES
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Create a mock HomeAssistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {}
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_register = MagicMock()
+    hass.services.async_remove = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    return hass
+
+
+@pytest.fixture
+def mock_config_entry() -> MagicMock:
+    """Create a mock config entry."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.data = {
+        CONF_REPOSITORIES: [
+            {
+                "repo_name": "test-repo",
+                "repo_url": "https://github.com/test/wakewords",
+                "selected_languages": ["en", "de"],
+            }
+        ]
+    }
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_empty_config_entry() -> MagicMock:
+    """Create a mock config entry with no repositories."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.data = {CONF_REPOSITORIES: []}
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Create a mock aiohttp session."""
+    session = AsyncMock()
+    session.closed = False
+    return session
+
+
+@pytest.fixture
+def github_api_response() -> list[dict]:
+    """Sample GitHub API response for repository contents."""
+    return [
+        {"name": "en", "type": "dir"},
+        {"name": "de", "type": "dir"},
+        {"name": "fr", "type": "dir"},
+        {"name": "README.md", "type": "file"},
+        {"name": ".gitignore", "type": "file"},
+    ]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from custom_components.wakeword_installer.const import (
     CONF_REPO_URL,
     CONF_REPOSITORIES,
     CONF_SELECTED_LANGUAGES,
+    DOMAIN,
 )
 
 
@@ -44,6 +45,7 @@ class TestConfigFlowUser:
         ) as mock_rm_cls:
             mock_rm = MagicMock()
             mock_rm.get_available_languages = AsyncMock(return_value=["en", "de", "fr"])
+            mock_rm.close = AsyncMock()
             mock_rm_cls.return_value = mock_rm
 
             result = await flow.async_step_user(
@@ -52,6 +54,8 @@ class TestConfigFlowUser:
                     CONF_REPO_URL: "https://github.com/test/wakewords",
                 }
             )
+
+            mock_rm.close.assert_called_once()
 
         assert result["type"] == "form"
         assert result["step_id"] == "select_languages"
@@ -65,6 +69,7 @@ class TestConfigFlowUser:
         ) as mock_rm_cls:
             mock_rm = MagicMock()
             mock_rm.get_available_languages = AsyncMock(return_value=[])
+            mock_rm.close = AsyncMock()
             mock_rm_cls.return_value = mock_rm
 
             result = await flow.async_step_user(
@@ -73,6 +78,8 @@ class TestConfigFlowUser:
                     CONF_REPO_URL: "https://github.com/test/wakewords",
                 }
             )
+
+            mock_rm.close.assert_called_once()
 
         assert result["type"] == "form"
         assert result["errors"]["base"] == "no_languages_found"
@@ -84,7 +91,10 @@ class TestConfigFlowUser:
         with patch(
             "custom_components.wakeword_installer.config_flow.RepositoryManager"
         ) as mock_rm_cls:
-            mock_rm_cls.side_effect = Exception("boom")
+            mock_rm = MagicMock()
+            mock_rm.get_available_languages = AsyncMock(side_effect=Exception("boom"))
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
 
             result = await flow.async_step_user(
                 user_input={
@@ -92,6 +102,8 @@ class TestConfigFlowUser:
                     CONF_REPO_URL: "https://github.com/test/wakewords",
                 }
             )
+
+            mock_rm.close.assert_called_once()
 
         assert result["type"] == "form"
         assert result["errors"]["base"] == "unknown"
@@ -146,6 +158,7 @@ class TestConfigFlowAddMore:
     async def test_done_creates_entry(self) -> None:
         flow = WakewordInstallerConfigFlow()
         flow.hass = MagicMock()
+        flow.context = {}
         flow.repositories = [
             {
                 CONF_REPO_NAME: "test",
@@ -154,11 +167,17 @@ class TestConfigFlowAddMore:
             }
         ]
 
+        # Mock async_set_unique_id and _abort_if_unique_id_configured
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+
         result = await flow.async_step_add_more(user_input={"add_another": False})
 
         assert result["type"] == "create_entry"
         assert result["title"] == "Wakeword Installer"
         assert result["data"][CONF_REPOSITORIES] == flow.repositories
+        flow.async_set_unique_id.assert_called_once_with(DOMAIN)
+        flow._abort_if_unique_id_configured.assert_called_once()
 
     async def test_add_another_returns_to_user_step(self) -> None:
         flow = WakewordInstallerConfigFlow()
@@ -178,8 +197,8 @@ class TestConfigFlowAddMore:
 class TestOptionsFlowInit:
     """Test the OptionsFlow initialization.
 
-    This tests the fix for Issue #2 — modern HA (2025.12+) makes config_entry
-    a read-only property on OptionsFlow.  The flow must NOT accept config_entry
+    This tests the fix for Issue #2 -- modern HA (2025.12+) makes config_entry
+    a read-only property on OptionsFlow. The flow must NOT accept config_entry
     in __init__; it accesses self.config_entry set by the framework.
     """
 
@@ -265,6 +284,7 @@ class TestOptionsFlowAddRepo:
         ) as mock_rm_cls:
             mock_rm = MagicMock()
             mock_rm.get_available_languages = AsyncMock(return_value=["en", "de"])
+            mock_rm.close = AsyncMock()
             mock_rm_cls.return_value = mock_rm
 
             result = await flow.async_step_add_repo(
@@ -273,6 +293,8 @@ class TestOptionsFlowAddRepo:
                     CONF_REPO_URL: "https://github.com/t/r",
                 }
             )
+
+            mock_rm.close.assert_called_once()
 
         assert result["type"] == "form"
         assert result["step_id"] == "manage_repos"
@@ -306,7 +328,41 @@ class TestOptionsFlowRemoveRepo:
                 user_input={"repo_to_remove": "repo1 (https://github.com/t/r1)"}
             )
 
+            mock_rm.close.assert_called_once()
+
         assert result["type"] == "form"
         assert result["step_id"] == "manage_repos"
         assert len(flow.repositories) == 1
         assert flow.repositories[0][CONF_REPO_NAME] == "repo2"
+
+
+@pytest.mark.asyncio
+class TestOptionsFlowInstallWakewords:
+    """Test install_wakewords step."""
+
+    async def test_install_closes_session(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.hass = MagicMock()
+        flow.repositories = [
+            {
+                CONF_REPO_NAME: "test-repo",
+                CONF_REPO_URL: "https://github.com/t/r",
+                CONF_SELECTED_LANGUAGES: ["en"],
+            }
+        ]
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.install_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            result = await flow.async_step_install_wakewords()
+
+            mock_rm.install_wakewords.assert_called_once()
+            mock_rm.close.assert_called_once()
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "install_complete"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,312 @@
+"""Tests for the Wakeword Installer config flow."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.wakeword_installer.config_flow import (
+    WakewordInstallerConfigFlow,
+    WakewordInstallerOptionsFlow,
+)
+from custom_components.wakeword_installer.const import (
+    CONF_REPO_NAME,
+    CONF_REPO_URL,
+    CONF_REPOSITORIES,
+    CONF_SELECTED_LANGUAGES,
+)
+
+
+# --- ConfigFlow tests ---
+
+
+@pytest.mark.asyncio
+class TestConfigFlowUser:
+    """Test the user step of the config flow."""
+
+    async def test_show_form_on_none_input(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+
+        result = await flow.async_step_user(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+
+    async def test_valid_repo_proceeds_to_language_selection(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.get_available_languages = AsyncMock(return_value=["en", "de", "fr"])
+            mock_rm_cls.return_value = mock_rm
+
+            result = await flow.async_step_user(
+                user_input={
+                    CONF_REPO_NAME: "test-repo",
+                    CONF_REPO_URL: "https://github.com/test/wakewords",
+                }
+            )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "select_languages"
+
+    async def test_empty_languages_shows_error(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.get_available_languages = AsyncMock(return_value=[])
+            mock_rm_cls.return_value = mock_rm
+
+            result = await flow.async_step_user(
+                user_input={
+                    CONF_REPO_NAME: "test-repo",
+                    CONF_REPO_URL: "https://github.com/test/wakewords",
+                }
+            )
+
+        assert result["type"] == "form"
+        assert result["errors"]["base"] == "no_languages_found"
+
+    async def test_exception_shows_unknown_error(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm_cls.side_effect = Exception("boom")
+
+            result = await flow.async_step_user(
+                user_input={
+                    CONF_REPO_NAME: "test-repo",
+                    CONF_REPO_URL: "https://github.com/test/wakewords",
+                }
+            )
+
+        assert result["type"] == "form"
+        assert result["errors"]["base"] == "unknown"
+
+
+@pytest.mark.asyncio
+class TestConfigFlowSelectLanguages:
+    """Test the language selection step."""
+
+    async def test_show_form_on_none_input(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+        flow.current_repo = {CONF_REPO_NAME: "test", CONF_REPO_URL: "https://github.com/t/r"}
+        flow.available_languages = ["en", "de"]
+
+        result = await flow.async_step_select_languages(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "select_languages"
+
+    async def test_selected_languages_stored(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+        flow.current_repo = {CONF_REPO_NAME: "test", CONF_REPO_URL: "https://github.com/t/r"}
+        flow.available_languages = ["en", "de", "fr"]
+
+        result = await flow.async_step_select_languages(
+            user_input={CONF_SELECTED_LANGUAGES: ["en", "de"]}
+        )
+
+        # Should proceed to add_more step
+        assert result["type"] == "form"
+        assert result["step_id"] == "add_more"
+        assert len(flow.repositories) == 1
+        assert flow.repositories[0][CONF_SELECTED_LANGUAGES] == ["en", "de"]
+
+
+@pytest.mark.asyncio
+class TestConfigFlowAddMore:
+    """Test the add_more step."""
+
+    async def test_show_form_on_none_input(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+        flow.repositories = [{CONF_REPO_NAME: "test"}]
+
+        result = await flow.async_step_add_more(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "add_more"
+
+    async def test_done_creates_entry(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+        flow.repositories = [
+            {
+                CONF_REPO_NAME: "test",
+                CONF_REPO_URL: "https://github.com/t/r",
+                CONF_SELECTED_LANGUAGES: ["en"],
+            }
+        ]
+
+        result = await flow.async_step_add_more(user_input={"add_another": False})
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == "Wakeword Installer"
+        assert result["data"][CONF_REPOSITORIES] == flow.repositories
+
+    async def test_add_another_returns_to_user_step(self) -> None:
+        flow = WakewordInstallerConfigFlow()
+        flow.hass = MagicMock()
+        flow.repositories = [{CONF_REPO_NAME: "test"}]
+
+        result = await flow.async_step_add_more(user_input={"add_another": True})
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+
+
+# --- OptionsFlow tests ---
+
+
+@pytest.mark.asyncio
+class TestOptionsFlowInit:
+    """Test the OptionsFlow initialization.
+
+    This tests the fix for Issue #2 — modern HA (2025.12+) makes config_entry
+    a read-only property on OptionsFlow.  The flow must NOT accept config_entry
+    in __init__; it accesses self.config_entry set by the framework.
+    """
+
+    async def test_init_reads_config_entry(self) -> None:
+        """Verify OptionsFlow can be created without arguments (Issue #2 fix)."""
+        flow = WakewordInstallerOptionsFlow()
+        # Set config_entry as the framework would
+        flow._config_entry = MagicMock(spec=ConfigEntry)
+        flow._config_entry.data = {
+            CONF_REPOSITORIES: [
+                {CONF_REPO_NAME: "repo1", CONF_REPO_URL: "https://github.com/t/r", CONF_SELECTED_LANGUAGES: ["en"]}
+            ]
+        }
+        # Patch config_entry property to return our mock
+        type(flow).config_entry = property(lambda self: self._config_entry)
+
+        result = await flow.async_step_init(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manage_repos"
+        assert len(flow.repositories) == 1
+
+    async def test_no_init_args_required(self) -> None:
+        """Ensure WakewordInstallerOptionsFlow() takes no arguments (Issue #2)."""
+        # This would raise TypeError if __init__ still required config_entry
+        flow = WakewordInstallerOptionsFlow()
+        assert flow is not None
+
+
+@pytest.mark.asyncio
+class TestOptionsFlowManageRepos:
+    """Test manage_repos step."""
+
+    async def test_show_form_on_none_input(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.repositories = [
+            {CONF_REPO_NAME: "repo1", CONF_REPO_URL: "https://github.com/t/r"}
+        ]
+
+        result = await flow.async_step_manage_repos(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manage_repos"
+
+    async def test_empty_repos_shows_placeholder(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.repositories = []
+
+        result = await flow.async_step_manage_repos(user_input=None)
+
+        assert result["type"] == "form"
+
+    async def test_done_action_creates_entry(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.repositories = []
+
+        result = await flow.async_step_manage_repos(user_input={"action": "done"})
+
+        assert result["type"] == "create_entry"
+
+
+@pytest.mark.asyncio
+class TestOptionsFlowAddRepo:
+    """Test add_repo step."""
+
+    async def test_show_form_on_none_input(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+
+        result = await flow.async_step_add_repo(user_input=None)
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "add_repo"
+
+    async def test_successful_add(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.hass = MagicMock()
+        flow.repositories = []
+        flow._config_entry = MagicMock()
+        type(flow).config_entry = property(lambda self: self._config_entry)
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.get_available_languages = AsyncMock(return_value=["en", "de"])
+            mock_rm_cls.return_value = mock_rm
+
+            result = await flow.async_step_add_repo(
+                user_input={
+                    CONF_REPO_NAME: "new-repo",
+                    CONF_REPO_URL: "https://github.com/t/r",
+                }
+            )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manage_repos"
+        assert len(flow.repositories) == 1
+        assert flow.repositories[0][CONF_REPO_NAME] == "new-repo"
+
+
+@pytest.mark.asyncio
+class TestOptionsFlowRemoveRepo:
+    """Test remove_repo step."""
+
+    async def test_remove_existing_repo(self) -> None:
+        flow = WakewordInstallerOptionsFlow()
+        flow.hass = MagicMock()
+        flow.repositories = [
+            {CONF_REPO_NAME: "repo1", CONF_REPO_URL: "https://github.com/t/r1"},
+            {CONF_REPO_NAME: "repo2", CONF_REPO_URL: "https://github.com/t/r2"},
+        ]
+        flow._config_entry = MagicMock()
+        type(flow).config_entry = property(lambda self: self._config_entry)
+
+        with patch(
+            "custom_components.wakeword_installer.config_flow.RepositoryManager"
+        ) as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.remove_repository_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            result = await flow.async_step_remove_repo(
+                user_input={"repo_to_remove": "repo1 (https://github.com/t/r1)"}
+            )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manage_repos"
+        assert len(flow.repositories) == 1
+        assert flow.repositories[0][CONF_REPO_NAME] == "repo2"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,215 @@
+"""Tests for the Wakeword Installer __init__ module."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.wakeword_installer import (
+    DOMAIN,
+    SERVICE_INSTALL_WAKEWORDS,
+    SERVICE_LIST_INSTALLED,
+    SERVICE_REFRESH_REPOSITORIES,
+    SERVICE_REMOVE_REPOSITORY_WAKEWORDS,
+    SERVICE_REMOVE_WAKEWORDS,
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+
+
+@pytest.mark.asyncio
+class TestAsyncSetup:
+    """Test async_setup."""
+
+    async def test_returns_true(self, mock_hass: MagicMock) -> None:
+        assert await async_setup(mock_hass, {}) is True
+
+
+@pytest.mark.asyncio
+class TestAsyncSetupEntry:
+    """Test async_setup_entry."""
+
+    async def test_registers_services(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager"):
+            result = await async_setup_entry(mock_hass, mock_config_entry)
+
+        assert result is True
+        assert DOMAIN in mock_hass.data
+        assert mock_config_entry.entry_id in mock_hass.data[DOMAIN]
+
+        # 5 services should be registered
+        assert mock_hass.services.async_register.call_count == 5
+
+        registered = [call.args[1] for call in mock_hass.services.async_register.call_args_list]
+        assert SERVICE_INSTALL_WAKEWORDS in registered
+        assert SERVICE_REMOVE_WAKEWORDS in registered
+        assert SERVICE_REMOVE_REPOSITORY_WAKEWORDS in registered
+        assert SERVICE_LIST_INSTALLED in registered
+        assert SERVICE_REFRESH_REPOSITORIES in registered
+
+    async def test_stores_entry_data(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager"):
+            await async_setup_entry(mock_hass, mock_config_entry)
+
+        assert mock_hass.data[DOMAIN][mock_config_entry.entry_id] == mock_config_entry.data
+
+    async def test_forwards_platforms(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager"):
+            await async_setup_entry(mock_hass, mock_config_entry)
+
+        mock_hass.config_entries.async_forward_entry_setups.assert_called_once_with(
+            mock_config_entry, []
+        )
+
+
+@pytest.mark.asyncio
+class TestAsyncUnloadEntry:
+    """Test async_unload_entry."""
+
+    async def test_successful_unload(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        # Setup first
+        mock_hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_config_entry.data}
+
+        result = await async_unload_entry(mock_hass, mock_config_entry)
+
+        assert result is True
+        assert mock_config_entry.entry_id not in mock_hass.data[DOMAIN]
+        assert mock_hass.services.async_remove.call_count == 5
+
+    async def test_failed_unload_keeps_data(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        mock_hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_config_entry.data}
+        mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+
+        result = await async_unload_entry(mock_hass, mock_config_entry)
+
+        assert result is False
+        assert mock_config_entry.entry_id in mock_hass.data[DOMAIN]
+        mock_hass.services.async_remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestServiceCalls:
+    """Test the service call handlers registered in async_setup_entry."""
+
+    def _get_service_handler(self, mock_hass: MagicMock, service_name: str):
+        """Find handler for a specific service from registered calls."""
+        for c in mock_hass.services.async_register.call_args_list:
+            if c.args[1] == service_name:
+                return c.args[2]
+        raise ValueError(f"Service {service_name} not registered")
+
+    async def test_install_wakewords_all_repos(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.install_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_INSTALL_WAKEWORDS)
+
+            call = MagicMock()
+            call.data = {}
+            await handler(call)
+
+            mock_rm.install_wakewords.assert_called_once()
+            mock_rm.close.assert_called()
+
+    async def test_install_wakewords_specific_repo(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.install_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_INSTALL_WAKEWORDS)
+
+            call = MagicMock()
+            call.data = {"repository": "test-repo"}
+            await handler(call)
+
+            mock_rm.install_wakewords.assert_called_once()
+
+    async def test_install_wakewords_wrong_repo_skips(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.install_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_INSTALL_WAKEWORDS)
+
+            call = MagicMock()
+            call.data = {"repository": "nonexistent-repo"}
+            await handler(call)
+
+            mock_rm.install_wakewords.assert_not_called()
+            mock_rm.close.assert_called()
+
+    async def test_remove_wakewords(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.remove_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_REMOVE_WAKEWORDS)
+
+            call = MagicMock()
+            call.data = {"repository": "test-repo", "languages": ["en"]}
+            await handler(call)
+
+            mock_rm.remove_wakewords.assert_called_once_with("test-repo", ["en"])
+            mock_rm.close.assert_called()
+
+    async def test_remove_repository_wakewords(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.remove_repository_wakewords = AsyncMock()
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_REMOVE_REPOSITORY_WAKEWORDS)
+
+            call = MagicMock()
+            call.data = {"repository": "test-repo"}
+            await handler(call)
+
+            mock_rm.remove_repository_wakewords.assert_called_once_with("test-repo")
+
+    async def test_list_installed(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.get_installed_wakewords = AsyncMock(return_value={})
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_LIST_INSTALLED)
+
+            call = MagicMock()
+            call.data = {}
+            await handler(call)
+
+            mock_rm.get_installed_wakewords.assert_called_once()
+
+    async def test_refresh_repositories(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:
+            mock_rm = MagicMock()
+            mock_rm.get_available_languages = AsyncMock(return_value=["en", "de"])
+            mock_rm.close = AsyncMock()
+            mock_rm_cls.return_value = mock_rm
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+            handler = self._get_service_handler(mock_hass, SERVICE_REFRESH_REPOSITORIES)
+
+            call = MagicMock()
+            call.data = {}
+            await handler(call)
+
+            mock_rm.get_available_languages.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,6 +31,7 @@ class TestAsyncSetupEntry:
     """Test async_setup_entry."""
 
     async def test_registers_services(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        mock_hass.services.has_service = MagicMock(return_value=False)
         with patch("custom_components.wakeword_installer.RepositoryManager"):
             result = await async_setup_entry(mock_hass, mock_config_entry)
 
@@ -47,6 +48,17 @@ class TestAsyncSetupEntry:
         assert SERVICE_REMOVE_REPOSITORY_WAKEWORDS in registered
         assert SERVICE_LIST_INSTALLED in registered
         assert SERVICE_REFRESH_REPOSITORIES in registered
+
+    async def test_skips_service_registration_when_already_registered(
+        self, mock_hass: MagicMock, mock_config_entry: MagicMock
+    ) -> None:
+        """Second entry should not re-register services."""
+        mock_hass.services.has_service = MagicMock(return_value=True)
+        with patch("custom_components.wakeword_installer.RepositoryManager"):
+            result = await async_setup_entry(mock_hass, mock_config_entry)
+
+        assert result is True
+        mock_hass.services.async_register.assert_not_called()
 
     async def test_stores_entry_data(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
         with patch("custom_components.wakeword_installer.RepositoryManager"):
@@ -67,8 +79,8 @@ class TestAsyncSetupEntry:
 class TestAsyncUnloadEntry:
     """Test async_unload_entry."""
 
-    async def test_successful_unload(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
-        # Setup first
+    async def test_successful_unload_last_entry(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        """When last entry is unloaded, services should be removed."""
         mock_hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_config_entry.data}
 
         result = await async_unload_entry(mock_hass, mock_config_entry)
@@ -76,6 +88,19 @@ class TestAsyncUnloadEntry:
         assert result is True
         assert mock_config_entry.entry_id not in mock_hass.data[DOMAIN]
         assert mock_hass.services.async_remove.call_count == 5
+
+    async def test_successful_unload_not_last_entry(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
+        """When other entries remain, services should NOT be removed."""
+        mock_hass.data[DOMAIN] = {
+            mock_config_entry.entry_id: mock_config_entry.data,
+            "other_entry": {"some": "data"},
+        }
+
+        result = await async_unload_entry(mock_hass, mock_config_entry)
+
+        assert result is True
+        assert mock_config_entry.entry_id not in mock_hass.data[DOMAIN]
+        mock_hass.services.async_remove.assert_not_called()
 
     async def test_failed_unload_keeps_data(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
         mock_hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_config_entry.data}
@@ -97,7 +122,7 @@ class TestServiceCalls:
         for c in mock_hass.services.async_register.call_args_list:
             if c.args[1] == service_name:
                 return c.args[2]
-        raise ValueError(f"Service {service_name} not registered")
+        raise ValueError("Service %s not registered" % service_name)
 
     async def test_install_wakewords_all_repos(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
         with patch("custom_components.wakeword_installer.RepositoryManager") as mock_rm_cls:

--- a/tests/test_repository_manager.py
+++ b/tests/test_repository_manager.py
@@ -1,0 +1,249 @@
+"""Tests for the RepositoryManager."""
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.wakeword_installer.repository_manager import RepositoryManager
+
+
+@pytest.fixture
+def repo_manager(mock_hass: MagicMock) -> RepositoryManager:
+    """Create a RepositoryManager with mocked session."""
+    with patch("custom_components.wakeword_installer.repository_manager.aiohttp.ClientSession") as mock_cs:
+        manager = RepositoryManager(mock_hass)
+        # Replace with a controllable mock
+        manager.session = AsyncMock()
+        manager.session.closed = False
+        return manager
+
+
+# --- URL conversion tests ---
+
+
+class TestConvertToApiUrl:
+    """Test _convert_to_api_url."""
+
+    def test_standard_github_url(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._convert_to_api_url("https://github.com/user/repo")
+        assert result == "https://api.github.com/repos/user/repo/contents"
+
+    def test_github_url_with_trailing_slash(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._convert_to_api_url("https://github.com/user/repo/")
+        assert result == "https://api.github.com/repos/user/repo/contents"
+
+    def test_github_url_with_git_suffix(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._convert_to_api_url("https://github.com/user/repo.git")
+        assert result == "https://api.github.com/repos/user/repo/contents"
+
+    def test_github_url_without_https(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._convert_to_api_url("github.com/user/repo")
+        assert result == "https://api.github.com/repos/user/repo/contents"
+
+    def test_invalid_url_raises(self, repo_manager: RepositoryManager) -> None:
+        with pytest.raises(HomeAssistantError, match="Invalid GitHub repository URL"):
+            repo_manager._convert_to_api_url("https://gitlab.com/user/repo")
+
+
+class TestGetDownloadUrl:
+    """Test _get_download_url."""
+
+    def test_standard_url(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._get_download_url("https://github.com/user/repo")
+        assert result == "https://github.com/user/repo/archive/refs/heads/main.zip"
+
+    def test_url_with_git_suffix(self, repo_manager: RepositoryManager) -> None:
+        result = repo_manager._get_download_url("https://github.com/user/repo.git")
+        assert result == "https://github.com/user/repo/archive/refs/heads/main.zip"
+
+    def test_invalid_url_raises(self, repo_manager: RepositoryManager) -> None:
+        with pytest.raises(HomeAssistantError):
+            repo_manager._get_download_url("https://gitlab.com/user/repo")
+
+
+class TestExtractRepoName:
+    """Test _extract_repo_name."""
+
+    def test_standard_url(self, repo_manager: RepositoryManager) -> None:
+        assert repo_manager._extract_repo_name("https://github.com/user/my-repo") == "my-repo"
+
+    def test_url_with_git_suffix(self, repo_manager: RepositoryManager) -> None:
+        assert repo_manager._extract_repo_name("https://github.com/user/my-repo.git") == "my-repo"
+
+    def test_url_without_https(self, repo_manager: RepositoryManager) -> None:
+        assert repo_manager._extract_repo_name("github.com/user/my-repo") == "my-repo"
+
+    def test_unknown_url(self, repo_manager: RepositoryManager) -> None:
+        assert repo_manager._extract_repo_name("https://gitlab.com/user/repo") == "unknown-repo"
+
+
+# --- Async operation tests ---
+
+
+@pytest.mark.asyncio
+class TestGetAvailableLanguages:
+    """Test get_available_languages."""
+
+    @staticmethod
+    def _mock_context_manager(response):
+        """Create a mock async context manager that returns the given response."""
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    async def test_returns_sorted_language_dirs(
+        self, repo_manager: RepositoryManager, github_api_response: list[dict]
+    ) -> None:
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=github_api_response)
+        repo_manager.session.get = MagicMock(return_value=self._mock_context_manager(mock_response))
+
+        result = await repo_manager.get_available_languages("https://github.com/test/wakewords")
+        assert result == ["de", "en", "fr"]
+
+    async def test_non_200_raises(self, repo_manager: RepositoryManager) -> None:
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        repo_manager.session.get = MagicMock(return_value=self._mock_context_manager(mock_response))
+
+        with pytest.raises(HomeAssistantError, match="Invalid repository structure"):
+            await repo_manager.get_available_languages("https://github.com/test/wakewords")
+
+    async def test_empty_repo_returns_empty(self, repo_manager: RepositoryManager) -> None:
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=[{"name": "README.md", "type": "file"}])
+        repo_manager.session.get = MagicMock(return_value=self._mock_context_manager(mock_response))
+
+        result = await repo_manager.get_available_languages("https://github.com/test/wakewords")
+        assert result == []
+
+
+@pytest.mark.asyncio
+class TestClose:
+    """Test session closing."""
+
+    async def test_close_open_session(self, repo_manager: RepositoryManager) -> None:
+        repo_manager.session.closed = False
+        await repo_manager.close()
+        repo_manager.session.close.assert_called_once()
+
+    async def test_close_already_closed(self, repo_manager: RepositoryManager) -> None:
+        repo_manager.session.closed = True
+        await repo_manager.close()
+        repo_manager.session.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestInstallWakewords:
+    """Test install_wakewords with a real zip file."""
+
+    async def test_install_creates_files(self, repo_manager: RepositoryManager) -> None:
+        """Test the full install flow with a real temp zip containing tflite files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_path = Path(tmpdir) / "openwakeword"
+
+            # Build a real zip that mimics a GitHub archive
+            zip_path = Path(tmpdir) / "repo.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("repo-main/en/hey_jarvis.tflite", b"fake-model-en")
+                zf.writestr("repo-main/de/hallo_jarvis.tflite", b"fake-model-de")
+                zf.writestr("repo-main/fr/bonjour.tflite", b"fake-model-fr")
+
+            # Patch constants and download to use our temp zip
+            with (
+                patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)),
+                patch.object(repo_manager, "_download_file", new_callable=AsyncMock) as mock_dl,
+            ):
+                # Make _download_file copy our pre-built zip to the expected path
+                async def fake_download(url, dest):
+                    import shutil
+                    shutil.copy2(zip_path, dest)
+
+                mock_dl.side_effect = fake_download
+
+                await repo_manager.install_wakewords(
+                    "https://github.com/test/wakewords",
+                    ["en", "de"],
+                    "test-repo",
+                )
+
+            # Verify tflite files were installed (en and de, not fr)
+            installed = list(install_path.glob("*.tflite"))
+            names = sorted(f.name for f in installed)
+            assert len(names) == 2
+            assert any("en" in n for n in names)
+            assert any("de" in n for n in names)
+            assert not any("fr" in n for n in names)
+
+
+@pytest.mark.asyncio
+class TestRemoveWakewords:
+    """Test wakeword removal."""
+
+    async def test_remove_specific_languages(self, repo_manager: RepositoryManager) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_path = Path(tmpdir)
+            # Create fake installed files
+            (install_path / "en_test-repo_hey.tflite").write_bytes(b"x")
+            (install_path / "de_test-repo_hallo.tflite").write_bytes(b"x")
+
+            with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
+                await repo_manager.remove_wakewords("test-repo", ["en"])
+
+            remaining = list(install_path.glob("*.tflite"))
+            assert len(remaining) == 1
+            assert "de" in remaining[0].name
+
+    async def test_remove_all_for_repo(self, repo_manager: RepositoryManager) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_path = Path(tmpdir)
+            (install_path / "en_test-repo_hey.tflite").write_bytes(b"x")
+            (install_path / "de_test-repo_hallo.tflite").write_bytes(b"x")
+            (install_path / "en_other-repo_hi.tflite").write_bytes(b"x")
+
+            with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
+                await repo_manager.remove_wakewords("test-repo", languages=None)
+
+            remaining = list(install_path.glob("*.tflite"))
+            assert len(remaining) == 1
+            assert "other-repo" in remaining[0].name
+
+
+@pytest.mark.asyncio
+class TestGetInstalledWakewords:
+    """Test listing installed wakewords."""
+
+    async def test_returns_grouped_by_language(self, repo_manager: RepositoryManager) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_path = Path(tmpdir)
+            (install_path / "en_repo_hey.tflite").write_bytes(b"x")
+            (install_path / "en_repo_hi.tflite").write_bytes(b"x")
+            (install_path / "de_repo_hallo.tflite").write_bytes(b"x")
+
+            with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
+                result = await repo_manager.get_installed_wakewords()
+
+            assert "en" in result
+            assert "de" in result
+            assert len(result["en"]) == 2
+            assert len(result["de"]) == 1
+
+    async def test_empty_dir_returns_empty(self, repo_manager: RepositoryManager) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(tmpdir)):
+                result = await repo_manager.get_installed_wakewords()
+            assert result == {}
+
+    async def test_nonexistent_dir_returns_empty(self, repo_manager: RepositoryManager) -> None:
+        with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", "/nonexistent/path"):
+            result = await repo_manager.get_installed_wakewords()
+        assert result == {}

--- a/tests/test_repository_manager.py
+++ b/tests/test_repository_manager.py
@@ -114,7 +114,7 @@ class TestGetAvailableLanguages:
         mock_response.status = 404
         repo_manager.session.get = MagicMock(return_value=self._mock_context_manager(mock_response))
 
-        with pytest.raises(HomeAssistantError, match="Invalid repository structure"):
+        with pytest.raises(HomeAssistantError, match="Failed to fetch repository contents"):
             await repo_manager.get_available_languages("https://github.com/test/wakewords")
 
     async def test_empty_repo_returns_empty(self, repo_manager: RepositoryManager) -> None:
@@ -180,9 +180,9 @@ class TestInstallWakewords:
             installed = list(install_path.glob("*.tflite"))
             names = sorted(f.name for f in installed)
             assert len(names) == 2
-            assert any("en" in n for n in names)
-            assert any("de" in n for n in names)
-            assert not any("fr" in n for n in names)
+            # Format: {repo_name}_{language}_{original_name}
+            assert "test-repo_en_hey_jarvis.tflite" in names
+            assert "test-repo_de_hallo_jarvis.tflite" in names
 
 
 @pytest.mark.asyncio
@@ -192,9 +192,9 @@ class TestRemoveWakewords:
     async def test_remove_specific_languages(self, repo_manager: RepositoryManager) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             install_path = Path(tmpdir)
-            # Create fake installed files
-            (install_path / "en_test-repo_hey.tflite").write_bytes(b"x")
-            (install_path / "de_test-repo_hallo.tflite").write_bytes(b"x")
+            # Files in format: {repo_name}_{language}_{original_name}
+            (install_path / "test-repo_en_hey.tflite").write_bytes(b"x")
+            (install_path / "test-repo_de_hallo.tflite").write_bytes(b"x")
 
             with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
                 await repo_manager.remove_wakewords("test-repo", ["en"])
@@ -206,9 +206,10 @@ class TestRemoveWakewords:
     async def test_remove_all_for_repo(self, repo_manager: RepositoryManager) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             install_path = Path(tmpdir)
-            (install_path / "en_test-repo_hey.tflite").write_bytes(b"x")
-            (install_path / "de_test-repo_hallo.tflite").write_bytes(b"x")
-            (install_path / "en_other-repo_hi.tflite").write_bytes(b"x")
+            # Files in format: {repo_name}_{language}_{original_name}
+            (install_path / "test-repo_en_hey.tflite").write_bytes(b"x")
+            (install_path / "test-repo_de_hallo.tflite").write_bytes(b"x")
+            (install_path / "other-repo_en_hi.tflite").write_bytes(b"x")
 
             with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
                 await repo_manager.remove_wakewords("test-repo", languages=None)
@@ -225,9 +226,10 @@ class TestGetInstalledWakewords:
     async def test_returns_grouped_by_language(self, repo_manager: RepositoryManager) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             install_path = Path(tmpdir)
-            (install_path / "en_repo_hey.tflite").write_bytes(b"x")
-            (install_path / "en_repo_hi.tflite").write_bytes(b"x")
-            (install_path / "de_repo_hallo.tflite").write_bytes(b"x")
+            # Files in format: {repo_name}_{language}_{original_name}
+            (install_path / "repo_en_hey.tflite").write_bytes(b"x")
+            (install_path / "repo_en_hi.tflite").write_bytes(b"x")
+            (install_path / "repo_de_hallo.tflite").write_bytes(b"x")
 
             with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)):
                 result = await repo_manager.get_installed_wakewords()
@@ -247,3 +249,43 @@ class TestGetInstalledWakewords:
         with patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", "/nonexistent/path"):
             result = await repo_manager.get_installed_wakewords()
         assert result == {}
+
+
+@pytest.mark.asyncio
+class TestZipSlipProtection:
+    """Test that zip-slip attacks are prevented."""
+
+    async def test_malicious_path_is_skipped(self, repo_manager: RepositoryManager) -> None:
+        """Verify that zip entries with path traversal are skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_path = Path(tmpdir) / "openwakeword"
+
+            zip_path = Path(tmpdir) / "evil.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                # Normal file
+                zf.writestr("repo-main/en/good.tflite", b"safe")
+                # Malicious path traversal entry
+                zf.writestr("repo-main/en/../../etc/evil.tflite", b"evil")
+
+            with (
+                patch("custom_components.wakeword_installer.repository_manager.WAKEWORD_INSTALL_PATH", str(install_path)),
+                patch.object(repo_manager, "_download_file", new_callable=AsyncMock) as mock_dl,
+            ):
+                async def fake_download(url, dest):
+                    import shutil
+                    shutil.copy2(zip_path, dest)
+
+                mock_dl.side_effect = fake_download
+
+                await repo_manager.install_wakewords(
+                    "https://github.com/test/wakewords",
+                    ["en"],
+                    "test-repo",
+                )
+
+            installed = list(install_path.glob("*.tflite"))
+            names = [f.name for f in installed]
+            # Only the safe file should be installed
+            assert "test-repo_en_good.tflite" in names
+            # The evil file should NOT exist outside the install path
+            assert not Path(tmpdir).joinpath("etc/evil.tflite").exists()


### PR DESCRIPTION
## Summary
- **Fix Issue #2**: Remove `config_entry` from `OptionsFlow.__init__()` — HA 2025.12+ makes it a read-only property set by the framework
- **Fix Issue #1**: Confirms `async_forward_entry_setups` (plural) is already correct in current code; the reported `AttributeError` was from an older version
- **Modernize APIs**: Replace deprecated `FlowResult` with `ConfigFlowResult`, replace `asyncio.get_event_loop().run_in_executor` with `hass.async_add_executor_job`
- **Add 53 comprehensive tests** covering config_flow, __init__, and repository_manager
- **CI matrix testing** against HA 2025.3, 2025.12, and 2026.2 with Python 3.11 and 3.12

## Changes
| File | Change |
|------|--------|
| `config_flow.py` | Remove OptionsFlow `__init__`, use framework `self.config_entry`, replace `FlowResult` → `ConfigFlowResult` |
| `repository_manager.py` | Replace deprecated `asyncio.get_event_loop()` with `hass.async_add_executor_job` |
| `manifest.json` | Bump version to 1.1.0 |
| `tests/` | New test suite: `test_config_flow.py`, `test_init.py`, `test_repository_manager.py`, `conftest.py` |
| `ci.yaml` | Add pytest step with HA version matrix |
| `pyproject.toml` | Add pytest config section |
| `requirements-dev.txt` | Add pytest, pytest-asyncio, pytest-cov |

## Test plan
- [x] All 53 tests pass locally
- [ ] CI matrix passes for all HA version + Python combinations
- [ ] HACS validation passes

Closes #1, Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config flows and service wiring plus zip download/extraction logic, which can impact setup/upgrade paths and file writes. Added tests and CI matrix reduce risk, but behavioral changes around multi-entry service handling and install safety checks warrant review.
> 
> **Overview**
> Fixes Home Assistant 2025.12+ compatibility by updating the config/option flows to use `ConfigFlowResult` and to rely on framework-provided `OptionsFlow.config_entry` (no custom `__init__`), plus enforcing a unique config entry.
> 
> Reworks integration service registration to be **single-instance** (registered once, removed only when the last entry unloads) and makes service handlers operate across all stored entries rather than a single `entry.data`.
> 
> Hardens `RepositoryManager` by moving blocking filesystem work to `hass.async_add_executor_job`, adding HTTP timeouts and download size limits, and adding zip-slip protection during extraction; also updates wakeword filename parsing/removal to match the `{repo}_{language}_{name}.tflite` format.
> 
> Adds a full pytest suite + pytest config, updates CI to run tests against a HA/Python matrix, and bumps metadata (`manifest.json` version/iot_class, `hacs.json`, `renovate.json`, workflow action versions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f00ce659025e322e72d64a7fa6dff0824917c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->